### PR TITLE
fix(spec-07): tighten LLM error handling

### DIFF
--- a/src/ai_psychiatrist/agents/judge.py
+++ b/src/ai_psychiatrist/agents/judge.py
@@ -11,6 +11,7 @@ from ai_psychiatrist.domain.entities import (
     Transcript,
 )
 from ai_psychiatrist.domain.enums import EvaluationMetric
+from ai_psychiatrist.domain.exceptions import LLMError
 from ai_psychiatrist.domain.value_objects import EvaluationScore
 from ai_psychiatrist.infrastructure.llm.responses import extract_score_from_text
 from ai_psychiatrist.infrastructure.logging import get_logger
@@ -115,7 +116,7 @@ class JudgeAgent:
                 user_prompt=prompt,
                 temperature=0.0,
             )
-        except Exception as e:
+        except LLMError as e:
             logger.error(
                 "LLM call failed during metric evaluation",
                 metric=metric.value,
@@ -125,7 +126,7 @@ class JudgeAgent:
             return EvaluationScore(
                 metric=metric,
                 score=3,
-                explanation=f"LLM evaluation failed: {e!s}",
+                explanation="LLM evaluation failed; default score used.",
             )
 
         # Extract score from response


### PR DESCRIPTION
## Summary
- Narrow JudgeAgent error handling to LLMError and avoid leaking error text into prompts
- Add unit test for LLMError fallback
- Fix 'frequency' typo and align spec example with error handling

## Testing
- .....                                                                    [100%]
5 passed in 0.25s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling error in validation documentation ("frequecy" → "frequency")
  * Enhanced evaluation robustness: metric evaluation now returns a neutral default score instead of failing when errors occur, enabling continued system operation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->